### PR TITLE
Nettoyage du modèle Order

### DIFF
--- a/orders/models.py
+++ b/orders/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from accounts.models import User, Address
+from accounts.models import User
 from products.models import Listing
 
 
@@ -16,21 +16,6 @@ class CartItem(models.Model):
 
     def __str__(self):
         return f"{self.quantity} of {self.listing} reserved by {self.buyer}"
-
-
-class CartItem(models.Model):
-    buyer = models.ForeignKey(User, on_delete=models.CASCADE, related_name="cart_items")
-    offer = models.ForeignKey(Offer, on_delete=models.CASCADE, related_name="cart_items")
-    quantity = models.PositiveIntegerField(default=1)
-    reserved_until = models.DateTimeField()
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
-
-    class Meta:
-        unique_together = ("buyer", "offer")
-
-    def __str__(self):
-        return f"{self.quantity} of {self.offer} reserved by {self.buyer}"
 
 
 class Order(models.Model):

--- a/orders/views.py
+++ b/orders/views.py
@@ -1,6 +1,6 @@
 from rest_framework import viewsets
 from decimal import Decimal
-from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from rest_framework.permissions import IsAuthenticated
 from rest_framework import serializers
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
@@ -12,7 +12,6 @@ from accounts.permissions import IsBuyer, IsSeller
 from accounts.models import Address
 from django.contrib.auth import get_user_model
 from django.utils import timezone
-from django.db.models import Q
 from datetime import timedelta
 
 User = get_user_model()
@@ -44,34 +43,6 @@ class CartItemViewSet(viewsets.ModelViewSet):
             raise serializers.ValidationError('Listing is reserved')
         reserved_until = now + timedelta(minutes=getattr(settings, 'CART_RESERVATION_MINUTES', 30))
         serializer.save(buyer=self.request.user, listing=listing, quantity=quantity, reserved_until=reserved_until)
-
-
-
-class CartItemViewSet(viewsets.ModelViewSet):
-    serializer_class = CartItemSerializer
-    permission_classes = [IsAuthenticated]
-
-    def get_queryset(self):
-        if getattr(self, 'swagger_fake_view', False):
-            return CartItem.objects.none()
-        user = self.request.user
-        now = timezone.now()
-        # Clean expired reservations
-        CartItem.objects.filter(reserved_until__lt=now).delete()
-        return CartItem.objects.filter(buyer=user)
-
-    def perform_create(self, serializer):
-        offer_id = self.request.data.get('offer')
-        quantity = int(self.request.data.get('quantity', 1))
-        try:
-            offer = Offer.objects.get(id=offer_id, status='pending')
-        except Offer.DoesNotExist:
-            raise serializers.ValidationError('Invalid offer')
-        now = timezone.now()
-        if CartItem.objects.filter(offer=offer, reserved_until__gt=now).exclude(buyer=self.request.user).exists():
-            raise serializers.ValidationError('Offer is reserved')
-        reserved_until = now + timedelta(minutes=getattr(settings, 'CART_RESERVATION_MINUTES', 30))
-        serializer.save(buyer=self.request.user, offer=offer, quantity=quantity, reserved_until=reserved_until)
 
 
 class OrderViewSet(viewsets.ModelViewSet):
@@ -406,9 +377,6 @@ class OrderViewSet(viewsets.ModelViewSet):
 
         # Remove reservation from cart if exists
         CartItem.objects.filter(buyer=buyer, listing=listing).delete()
-
-        # Remove reservation from cart if exists
-        CartItem.objects.filter(buyer=buyer, offer=offer).delete()
 
         # Créer la commande
         serializer.save(


### PR DESCRIPTION
## Summary
- nettoie les modèles et vues en supprimant la vieille logique `Offer`
- retire la vue `CartItem` en double

## Testing
- `pip install -r requirements.txt`
- `DJANGO_SETTINGS_MODULE=core.settings pytest -q` *(échoue : OperationalError could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_b_68528a9ef4008332a36d2940b8e77160