### PR TITLE
Add search suggestion API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,9 @@ When using Docker you can run the suite inside the container:
 ```bash
 docker compose run web pytest
 ```
+
+## Search suggestions
+
+`GET /api/search/suggestions/?query=<text>` returns an array of suggestion strings
+matching the given query. Suggestions are pulled from product names, series and
+block fields and may include frequent search terms.

--- a/products/test_search_suggestions.py
+++ b/products/test_search_suggestions.py
@@ -1,0 +1,50 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from products.models import Product
+
+
+@pytest.mark.django_db
+def test_name_suggestions():
+    Product.objects.create(name="Pikachu", tcg_type="pokemon")
+    Product.objects.create(name="Pikaman", tcg_type="pokemon")
+    Product.objects.create(name="Bulbasaur", tcg_type="pokemon")
+
+    client = APIClient()
+    url = reverse("search-suggestions")
+    response = client.get(url, {"query": "Pika"})
+
+    assert response.status_code == 200
+    assert "Pikachu" in response.data
+    assert "Pikaman" in response.data
+    assert "Bulbasaur" not in response.data
+
+
+@pytest.mark.django_db
+def test_block_and_series_suggestions():
+    Product.objects.create(name="Charizard", block="Fire Block", series="Alpha", tcg_type="pokemon")
+    Product.objects.create(name="Mewtwo", block="Fire Tower", series="Beta", tcg_type="pokemon")
+
+    client = APIClient()
+    url = reverse("search-suggestions")
+    response = client.get(url, {"query": "Fire"})
+
+    assert response.status_code == 200
+    assert "Fire Block" in response.data
+    assert "Fire Tower" in response.data
+    # series not matched by 'Fire'
+    assert "Alpha" not in response.data
+
+
+@pytest.mark.django_db
+def test_empty_query_returns_empty():
+    Product.objects.create(name="Test", tcg_type="pokemon")
+
+    client = APIClient()
+    url = reverse("search-suggestions")
+    response = client.get(url, {"query": ""})
+
+    assert response.status_code == 200
+    assert response.data == []
+

--- a/products/urls.py
+++ b/products/urls.py
@@ -10,6 +10,7 @@ from .views import (
     VariantViewSet,
     ListingViewSet,
     CollectionViewSet,
+    SearchSuggestionView,
 )
 
 router = DefaultRouter()
@@ -25,4 +26,5 @@ router.register(r'collections', CollectionViewSet, basename='collection')
 
 urlpatterns = [
     path('', include(router.urls)),
+    path('search/suggestions/', SearchSuggestionView.as_view(), name='search-suggestions'),
 ]


### PR DESCRIPTION
## Summary
- implement `SearchSuggestionView` returning product field suggestions
- expose new route `/api/search/suggestions/`
- test suggestions for product names and series/block
- document endpoint in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_b_685312f2ff808332a353afef45b30e25